### PR TITLE
Remove AAS submission optional fields

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -26,10 +26,6 @@ affiliations:
 date: 21 November 2024
 bibliography: paper.bib
 
-# Optional fields if submitting to a AAS journal too, see this blog post:
-# https://blog.joss.theoj.org/2018/12/a-new-collaboration-with-aas-publishing
-aas-doi: 10.3847/xxxxx <- update this with the DOI from AAS once you know it.
-aas-journal: Astrophysical Journal <- The name of the AAS journal.
 ---
 
 # Summary


### PR DESCRIPTION
Removed optional AAS journal submission fields from the paper.

(This may solve the issue, as it appears to be trying to insert the logo of AAS.)